### PR TITLE
Add support for TP-LINK Archer T9UH

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -180,6 +180,7 @@ static struct usb_device_id rtw_usb_id_tbl[] ={
 	{USB_DEVICE(0x7392, 0xA834), .driver_info = RTL8814A}, /* Edimax - Edimax */
 	{USB_DEVICE(0x7392, 0xA833), .driver_info = RTL8814A}, /* Edimax - Edimax */
 	{USB_DEVICE(0x20f4, 0x809a), .driver_info = RTL8814A}, /* TRENDnet - TAC1900 */
+	{USB_DEVICE(0x2357, 0x0106), .driver_info = RTL8814A}, /* TP-LINK Archer T9UH */
 #endif /* CONFIG_RTL8814A */
 
 	{}	/* Terminating entry */


### PR DESCRIPTION
Adds USB ID's for TP-Link Archer T9UH. Tested on Fedora 26 with Kernel 4.12.9 x86_64