### PR TITLE
Remove use of get_monotonic_boottime() (kernel 4.20 fix)

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -350,7 +350,9 @@ rtw_cfg80211_default_mgmt_stypes[NUM_NL80211_IFTYPES] = {
 
 static u64 rtw_get_systime_us(void)
 {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,39))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,20,0))
+	return ktime_to_us(ktime_get_boottime());
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,39))
 	struct timespec ts;
 	get_monotonic_boottime(&ts);
 	return ((u64)ts.tv_sec*1000000) + ts.tv_nsec / 1000;


### PR DESCRIPTION
The function get_monotonic_boottime() is deprecated and removed in kernel version 4.20.

For more info see:

https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/diff/?id=976516404ff3fab2a8caa8bd6f5efc1437fed0b8

This fix is based on this commit in a similar project:

https://lore.kernel.org/patchwork/patch/948603/